### PR TITLE
Add protocol to discuss.atom.io link

### DIFF
--- a/lib/welcome.md
+++ b/lib/welcome.md
@@ -19,7 +19,7 @@ you need to know.
 5. Here is where you can get more help with Atom
    * The [Atom docs](https://www.atom.io/docs) contain Guides and the API
      reference.
-   * Discuss Atom at [discuss.atom.io](discuss.atom.io).
+   * Discuss Atom at [discuss.atom.io](http://discuss.atom.io).
    * `##atom` the [Atom IRC Channel](http://webchat.freenode.net/?channels=##atom).
      Chat with other Atom developers on freenode.
    * The [Atom Org](https://github.com/atom). This is where all GitHub created Atom


### PR DESCRIPTION
The `discuss.atom.io` link isn't clickable without the protocol in the Markdown when rendered to HTML.
