### PR TITLE
brought all lines under 80 char

### DIFF
--- a/docs/darwin/welcome.md
+++ b/docs/darwin/welcome.md
@@ -14,8 +14,8 @@
    * The [Atom docs](https://www.atom.io/docs) contain Guides and the API
      reference.
    * Discuss Atom at [discuss.atom.io](http://discuss.atom.io).
-   * The [Atom Org](https://github.com/atom). This is where all GitHub created Atom
-     packages can be found.
+   * The [Atom Org](https://github.com/atom). This is where all GitHub created
+     Atom packages can be found.
 
 4. If you ever want to see this buffer again use the command palette
    (`cmd-shift-P`) and search for `Welcome`.

--- a/docs/linux/welcome.md
+++ b/docs/linux/welcome.md
@@ -14,8 +14,8 @@
    * The [Atom docs](https://www.atom.io/docs) contain Guides and the API
      reference.
    * Discuss Atom at [discuss.atom.io](http://discuss.atom.io).
-   * The [Atom Org](https://github.com/atom). This is where all GitHub created Atom
-     packages can be found.
+   * The [Atom Org](https://github.com/atom). This is where all GitHub created
+     Atom packages can be found.
 
 4. If you ever want to see this buffer again use the command palette
    (`ctrl-shift-P`) and search for `Welcome`.

--- a/docs/win32/welcome.md
+++ b/docs/win32/welcome.md
@@ -14,8 +14,8 @@
    * The [Atom docs](https://www.atom.io/docs) contain Guides and the API
      reference.
    * Discuss Atom at [discuss.atom.io](http://discuss.atom.io).
-   * The [Atom Org](https://github.com/atom). This is where all GitHub created Atom
-     packages can be found.
+   * The [Atom Org](https://github.com/atom). This is where all GitHub created
+     Atom packages can be found.
 
 4. If you ever want to see this buffer again use the command palette
    (`ctrl-shift-P`) and search for `Welcome`.


### PR DESCRIPTION
Minor annoying fix for the OCDs out there. Wrap guides are set to 80 characters, and one line stuck out. Fixed it.
