### PR TITLE
Tweak copy describing the @atom org

### DIFF
--- a/lib/welcome-view.coffee
+++ b/lib/welcome-view.coffee
@@ -33,7 +33,7 @@ class WelcomeView extends ScrollView
           @ul =>
             @li => @raw 'The <a href="https://www.atom.io/docs" data-event="atom-docs">Atom docs</a> for Guides and the API reference.'
             @li => @raw 'The Atom forum at <a href="http://discuss.atom.io" data-event="discuss">discuss.atom.io</a>.'
-            @li => @raw 'The <a href="https://github.com/atom" data-event="atom-org">Atom Org</a>. This is where all GitHub created Atom packages can be found.'
+            @li => @raw 'The <a href="https://github.com/atom" data-event="atom-org">Atom Org</a>. This is where all GitHub-created Atom packages can be found.'
           @p class: 'welcome-note welcome-metrics', =>
              @raw '''
                 <strong>Note:</strong> To help us improve Atom, we anonymously

--- a/lib/welcome-view.coffee
+++ b/lib/welcome-view.coffee
@@ -33,7 +33,7 @@ class WelcomeView extends ScrollView
           @ul =>
             @li => @raw 'The <a href="https://www.atom.io/docs" data-event="atom-docs">Atom docs</a> for Guides and the API reference.'
             @li => @raw 'The Atom forum at <a href="http://discuss.atom.io" data-event="discuss">discuss.atom.io</a>.'
-            @li => @raw 'The <a href="https://github.com/atom" data-event="atom-org">Atom Org</a>. This is where all GitHub-created Atom packages can be found.'
+            @li => @raw 'The <a href="https://github.com/atom" data-event="atom-org">Atom org</a>. This is where all GitHub-created Atom packages can be found.'
           @p class: 'welcome-note welcome-metrics', =>
              @raw '''
                 <strong>Note:</strong> To help us improve Atom, we anonymously


### PR DESCRIPTION
A couple recommended copy tweaks for this sentence:

> The Atom Org. This is where all GitHub created Atom packages can be found.

- Hyphenate "GitHub-created" to make it clear that it's a single adjective describing the packages.
- Downcase "org". (Organization isn't a proper noun.)

#### Before

![before](https://cloud.githubusercontent.com/assets/2988/6310700/53c49d56-b927-11e4-9299-e481ef6a5baa.png)

#### After

![after](https://cloud.githubusercontent.com/assets/2988/6310684/3bc61068-b927-11e4-8418-4d3991b98f50.png)