### PR TITLE
Fixing platform detection regression for keystrokes in #30

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.0"
+    "atom-space-pen-views": "^2.0.0",
+    "underscore-plus": "1.x"
   }
 }


### PR DESCRIPTION
Attempting to fix issue #30 that I reported earlier. Using logic from `background-tips` package to determine the correct platform-specific keystrokes depending on the command listed in the guide.