### PR TITLE
Open metrics package directly

### DIFF
--- a/lib/welcome-view.coffee
+++ b/lib/welcome-view.coffee
@@ -39,7 +39,7 @@ class WelcomeView extends ScrollView
                 <strong>Note:</strong> To help us improve Atom, we anonymously
                 track usage metrics, such as launch time, screen size, and current
                 version. See the
-                <a href="https://github.com/atom/metrics" data-event="atom-metrics">atom/metrics</a>
+                <a class="js-metrics" data-event="atom-metrics">atom/metrics</a>
                 package for details and instructions to disable it.
               '''
 
@@ -54,6 +54,9 @@ class WelcomeView extends ScrollView
     @on 'click', 'a', ->
       eventName = $(this).attr('data-event')
       Reporter.sendEvent("clicked-welcome-#{eventName}-link") if eventName
+
+    @on 'click', 'a.js-metrics', ->
+      atom.workspace.open('atom://config/packages/metrics')
 
   serialize: ->
     deserializer: @constructor.name


### PR DESCRIPTION
- Depends on https://github.com/atom/settings-view/pull/614

Allows a user to click a link in the welcome pane that opens the metrics package in the settings view, rather than linking out to the site.