### PR TITLE
Fix specs by setting telemetryConsent to 'no'

### DIFF
--- a/spec/welcome-spec.coffee
+++ b/spec/welcome-spec.coffee
@@ -17,11 +17,12 @@ describe "Welcome", ->
       waitsFor ->
         atom.workspace.open.calls.length is 3
 
-    it "opens the telemetry consent pane and the welcome pane", ->
+    it "opens the telemetry consent pane and the welcome panes", ->
       panes = atom.workspace.getPanes()
       expect(panes).toHaveLength 2
       expect(panes[0].getItems()[0].getTitle()).toBe 'Telemetry Consent'
       expect(panes[0].getItems()[1].getTitle()).toBe 'Welcome'
+      expect(panes[1].getItems()[0].getTitle()).toBe 'Welcome Guide'
 
   describe "when `core.telemetryConsent` is not `undecided`", ->
     beforeEach ->

--- a/spec/welcome-spec.coffee
+++ b/spec/welcome-spec.coffee
@@ -6,109 +6,128 @@ describe "Welcome", ->
 
   beforeEach ->
     spyOn(atom.workspace, 'open').andCallThrough()
-    atom.config.set('core.telemetryConsent', 'no')
 
-    waitsForPromise ->
-      atom.packages.activatePackage("welcome")
-
-    waitsFor ->
-      atom.workspace.open.calls.length is 2
-
-  describe "when activated for the first time", ->
-    it "shows the welcome panes", ->
-      panes = atom.workspace.getPanes()
-      expect(panes).toHaveLength 2
-      expect(panes[0].getItems()[0].getTitle()).toBe 'Welcome'
-      expect(panes[1].getItems()[0].getTitle()).toBe 'Welcome Guide'
-
-  describe "the welcome:show command", ->
-    workspaceElement = null
-
+  describe "when `core.telemetryConsent` is 'undecided'", ->
     beforeEach ->
-      workspaceElement = atom.views.getView(atom.workspace)
+      atom.config.set('core.telemetryConsent', 'undecided')
 
-    it "shows the welcome buffer", ->
-      atom.workspace.getPanes().map (pane) -> pane.destroy()
-      expect(atom.workspace.getActivePaneItem()).toBeUndefined()
-      atom.commands.dispatch(workspaceElement, 'welcome:show')
+      waitsForPromise ->
+        atom.packages.activatePackage("welcome")
 
       waitsFor ->
-        atom.workspace.getActivePaneItem()
+        atom.workspace.open.calls.length is 3
 
-      runs ->
+    it "opens the telemetry consent pane and the welcome pane", ->
+      panes = atom.workspace.getPanes()
+      expect(panes).toHaveLength 2
+      expect(panes[0].getItems()[0].getTitle()).toBe 'Telemetry Consent'
+      expect(panes[0].getItems()[1].getTitle()).toBe 'Welcome'
+
+  describe "when `core.telemetryConsent` is not `undecided`", ->
+    beforeEach ->
+      atom.config.set('core.telemetryConsent', 'no')
+
+      waitsForPromise ->
+        atom.packages.activatePackage("welcome")
+
+      waitsFor ->
+        atom.workspace.open.calls.length is 2
+
+    describe "when activated for the first time", ->
+      it "shows the welcome panes", ->
         panes = atom.workspace.getPanes()
         expect(panes).toHaveLength 2
         expect(panes[0].getItems()[0].getTitle()).toBe 'Welcome'
+        expect(panes[1].getItems()[0].getTitle()).toBe 'Welcome Guide'
 
-  describe "deserializing the pane items", ->
-    [panes, guideView, welcomeView] = []
-    beforeEach ->
-      panes = atom.workspace.getPanes()
-      welcomeView = panes[0].getItems()[0]
-      guideView = panes[1].getItems()[0]
+    describe "the welcome:show command", ->
+      workspaceElement = null
 
-    describe "when GuideView is deserialized", ->
-      it "deserializes with no state", ->
-        {deserializer, uri} = guideView.serialize()
-        newGuideView = atom.deserializers.deserialize({deserializer, uri})
+      beforeEach ->
+        workspaceElement = atom.views.getView(atom.workspace)
 
-      it "remembers open sections", ->
-        guideView.find("details[data-section=\"snippets\"]").attr('open', 'open')
-        guideView.find("details[data-section=\"init-script\"]").attr('open', 'open')
-        serialized = guideView.serialize()
+      it "shows the welcome buffer", ->
+        atom.workspace.getPanes().map (pane) -> pane.destroy()
+        expect(atom.workspace.getActivePaneItem()).toBeUndefined()
+        atom.commands.dispatch(workspaceElement, 'welcome:show')
 
-        expect(serialized.openSections).toEqual ['init-script', 'snippets']
+        waitsFor ->
+          atom.workspace.getActivePaneItem()
 
-        newGuideView = atom.deserializers.deserialize(serialized)
+        runs ->
+          panes = atom.workspace.getPanes()
+          expect(panes).toHaveLength 2
+          expect(panes[0].getItems()[0].getTitle()).toBe 'Welcome'
 
-        expect(newGuideView.find("details[data-section=\"packages\"]")).not.toHaveAttr 'open'
-        expect(newGuideView.find("details[data-section=\"snippets\"]")).toHaveAttr 'open'
-        expect(newGuideView.find("details[data-section=\"init-script\"]")).toHaveAttr 'open'
+    describe "deserializing the pane items", ->
+      [panes, guideView, welcomeView] = []
+      beforeEach ->
+        panes = atom.workspace.getPanes()
+        welcomeView = panes[0].getItems()[0]
+        guideView = panes[1].getItems()[0]
 
-  describe "reporting events", ->
-    [panes, guideView, welcomeView] = []
-    beforeEach ->
-      panes = atom.workspace.getPanes()
-      welcomeView = panes[0].getItems()[0]
-      guideView = panes[1].getItems()[0]
+      describe "when GuideView is deserialized", ->
+        it "deserializes with no state", ->
+          {deserializer, uri} = guideView.serialize()
+          newGuideView = atom.deserializers.deserialize({deserializer, uri})
 
-      spyOn(Reporter, 'sendEvent')
+        it "remembers open sections", ->
+          guideView.find("details[data-section=\"snippets\"]").attr('open', 'open')
+          guideView.find("details[data-section=\"init-script\"]").attr('open', 'open')
+          serialized = guideView.serialize()
 
-    describe "GuideView events", ->
-      it "captures expand and collapse events", ->
-        expect(Reporter.sendEvent).not.toHaveBeenCalled()
+          expect(serialized.openSections).toEqual ['init-script', 'snippets']
 
-        guideView.find("details[data-section=\"packages\"] summary").click()
-        expect(Reporter.sendEvent).toHaveBeenCalledWith('expand-packages-section')
-        expect(Reporter.sendEvent).not.toHaveBeenCalledWith('collapse-packages-section')
+          newGuideView = atom.deserializers.deserialize(serialized)
 
-        guideView.find("details[data-section=\"packages\"]").attr('open', true)
-        guideView.find("details[data-section=\"packages\"] summary").click()
-        expect(Reporter.sendEvent).toHaveBeenCalledWith('collapse-packages-section')
+          expect(newGuideView.find("details[data-section=\"packages\"]")).not.toHaveAttr 'open'
+          expect(newGuideView.find("details[data-section=\"snippets\"]")).toHaveAttr 'open'
+          expect(newGuideView.find("details[data-section=\"init-script\"]")).toHaveAttr 'open'
 
-      it "captures button events", ->
-        spyOn(atom.commands, 'dispatch')
-        for detailElement in guideView.find('details')
-          detailElement = $(detailElement)
-          sectionName = detailElement.attr('data-section')
-          eventName = "clicked-#{sectionName}-cta"
-          primaryButton = detailElement.find('.btn-primary')
-          if primaryButton.length
-            expect(Reporter.sendEvent).not.toHaveBeenCalledWith(eventName)
-            primaryButton.click()
-            expect(Reporter.sendEvent).toHaveBeenCalledWith(eventName)
+    describe "reporting events", ->
+      [panes, guideView, welcomeView] = []
+      beforeEach ->
+        panes = atom.workspace.getPanes()
+        welcomeView = panes[0].getItems()[0]
+        guideView = panes[1].getItems()[0]
 
-  describe "when the reporter changes", ->
-    it "sends all queued events", ->
-      reporter1 = sendEvent: jasmine.createSpy('sendEvent')
-      reporter2 = sendEvent: jasmine.createSpy('sendEvent')
+        spyOn(Reporter, 'sendEvent')
 
-      Reporter.sendEvent('foo', 'bar', 'baz')
-      Reporter.sendEvent('foo2', 'bar2', 'baz2')
-      Reporter.setReporter(reporter1)
+      describe "GuideView events", ->
+        it "captures expand and collapse events", ->
+          expect(Reporter.sendEvent).not.toHaveBeenCalled()
 
-      expect(reporter1.sendEvent).toHaveBeenCalledWith 'welcome-v1', 'foo', 'bar', 'baz'
-      expect(reporter1.sendEvent).toHaveBeenCalledWith 'welcome-v1', 'foo2', 'bar2', 'baz2'
+          guideView.find("details[data-section=\"packages\"] summary").click()
+          expect(Reporter.sendEvent).toHaveBeenCalledWith('expand-packages-section')
+          expect(Reporter.sendEvent).not.toHaveBeenCalledWith('collapse-packages-section')
 
-      Reporter.setReporter(reporter2)
-      expect(reporter2.sendEvent.callCount).toBe 0
+          guideView.find("details[data-section=\"packages\"]").attr('open', true)
+          guideView.find("details[data-section=\"packages\"] summary").click()
+          expect(Reporter.sendEvent).toHaveBeenCalledWith('collapse-packages-section')
+
+        it "captures button events", ->
+          spyOn(atom.commands, 'dispatch')
+          for detailElement in guideView.find('details')
+            detailElement = $(detailElement)
+            sectionName = detailElement.attr('data-section')
+            eventName = "clicked-#{sectionName}-cta"
+            primaryButton = detailElement.find('.btn-primary')
+            if primaryButton.length
+              expect(Reporter.sendEvent).not.toHaveBeenCalledWith(eventName)
+              primaryButton.click()
+              expect(Reporter.sendEvent).toHaveBeenCalledWith(eventName)
+
+    describe "when the reporter changes", ->
+      it "sends all queued events", ->
+        reporter1 = sendEvent: jasmine.createSpy('sendEvent')
+        reporter2 = sendEvent: jasmine.createSpy('sendEvent')
+
+        Reporter.sendEvent('foo', 'bar', 'baz')
+        Reporter.sendEvent('foo2', 'bar2', 'baz2')
+        Reporter.setReporter(reporter1)
+
+        expect(reporter1.sendEvent).toHaveBeenCalledWith 'welcome-v1', 'foo', 'bar', 'baz'
+        expect(reporter1.sendEvent).toHaveBeenCalledWith 'welcome-v1', 'foo2', 'bar2', 'baz2'
+
+        Reporter.setReporter(reporter2)
+        expect(reporter2.sendEvent.callCount).toBe 0

--- a/spec/welcome-spec.coffee
+++ b/spec/welcome-spec.coffee
@@ -6,6 +6,7 @@ describe "Welcome", ->
 
   beforeEach ->
     spyOn(atom.workspace, 'open').andCallThrough()
+    atom.config.set('core.telemetryConsent', 'no')
 
     waitsForPromise ->
       atom.packages.activatePackage("welcome")


### PR DESCRIPTION
After we enabled the telemetry consent tab, and similarly to atom/atom#12529, this spec suite started failing because some of the tests for this package were relying on not having extraneous tabs. 

With this pull-request, we set `telemetryConsent` to `no`, so that specs are 💚 again.

/cc: @atom/core 