### PR TITLE
fix accessibility warnings

### DIFF
--- a/lib/consent-view.js
+++ b/lib/consent-view.js
@@ -13,7 +13,7 @@ export default class ConsentView {
       <div className='welcome'>
         <div className='welcome-container'>
           <div className='header'>
-            <a href='https://atom.io/'>
+            <a title='atom.io' href='https://atom.io/'>
               <svg class="welcome-logo" width="330px" height="68px" viewBox="0 0 330 68" version="1.1">
                 <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                     <g transform="translate(2.000000, 1.000000)">
@@ -57,7 +57,7 @@ export default class ConsentView {
               <span className="inline"> with </span>
               <span className="icon icon-heart"></span>
               <span className="inline"> by </span>
-              <a className="icon icon-logo-github" href="https://github.com" />
+              <a className="icon icon-logo-github" title="GitHub" href="https://github.com" />
             </p>
           </div>
         </div>


### PR DESCRIPTION
Using electron/devtron#87 I started going through Atom to find places that generated Accessibility Warnings/Errors.

# Report Screenshot

**Note** the "contrast ratio" warnings are likely Theme-specific (I used the atom-dark theme).

![image](https://cloud.githubusercontent.com/assets/253202/18975907/c77adc24-867b-11e6-9172-78c75e481beb.png)

PS: Any thoughts on whether CI audit tests should be sprinkled in as fixes are made to the various repositories?