### PR TITLE
"Version control with Git and GitHub" section

### DIFF
--- a/lib/guide-view.js
+++ b/lib/guide-view.js
@@ -77,7 +77,7 @@ export default class GuideView {
                 </p>
                 <p className='welcome-note'>
                   <strong>Next time:</strong> You can toggle the Git tab by clicking on the
-                  <span className="icon icon-diff" /> button in your status bar.
+                  <span className='icon icon-diff' /> button in your status bar.
                 </p>
               </div>
             </details>
@@ -298,12 +298,12 @@ export default class GuideView {
     atom.commands.dispatch(atom.views.getView(atom.workspace), 'application:open')
   }
 
-  didClickGitButton() {
+  didClickGitButton () {
     this.props.reporterProxy.sendEvent('clicked-git-cta')
     atom.commands.dispatch(atom.views.getView(atom.workspace), 'github:toggle-git-tab')
   }
 
-  didClickGitHubButton() {
+  didClickGitHubButton () {
     this.props.reporterProxy.sendEvent('clicked-github-cta')
     atom.commands.dispatch(atom.views.getView(atom.workspace), 'github:toggle-github-tab')
   }

--- a/lib/guide-view.js
+++ b/lib/guide-view.js
@@ -68,10 +68,10 @@ export default class GuideView {
                   the comfort of your editor. Collaborate with other developers on GitHub.
                 </p>
                 <p>
-                  <button onclick={this.didClickGitButton} className='btn btn-primary'>
+                  <button onclick={this.didClickGitButton} className='btn btn-primary inline-block'>
                     Open the Git panel
                   </button>
-                  <button onclick={this.didClickGitHubButton} className='btn btn-primary'>
+                  <button onclick={this.didClickGitHubButton} className='btn btn-primary inline-block'>
                     Open the GitHub panel
                   </button>
                 </p>

--- a/lib/guide-view.js
+++ b/lib/guide-view.js
@@ -7,6 +7,8 @@ export default class GuideView {
   constructor (props) {
     this.props = props
     this.didClickProjectButton = this.didClickProjectButton.bind(this)
+    this.didClickGitButton = this.didClickGitButton.bind(this)
+    this.didClickGitHubButton = this.didClickGitHubButton.bind(this)
     this.didClickPackagesButton = this.didClickPackagesButton.bind(this)
     this.didClickThemesButton = this.didClickThemesButton.bind(this)
     this.didClickStylingButton = this.didClickStylingButton.bind(this)
@@ -49,6 +51,33 @@ export default class GuideView {
                   <strong>Next time:</strong> You can also open projects from
                   the menu, keyboard shortcut or by dragging a folder onto the
                   Atom dock icon.
+                </p>
+              </div>
+            </details>
+
+            <details className='welcome-card' {...this.getSectionProps('git')}>
+              <summary className='welcome-summary icon icon-mark-github'>
+                Version control with <span class='welcome-highlight'>Git and GitHub</span>
+              </summary>
+              <div className='welcome-detail'>
+                <p>
+                  <img className='welcome-img' src='atom://welcome/assets/package.svg' />
+                </p>
+                <p>
+                  Track changes to your code as you work. Branch, commit, push, and pull without leaving
+                  the comfort of your editor. Collaborate with other developers on GitHub.
+                </p>
+                <p>
+                  <button onclick={this.didClickGitButton} className='btn btn-primary'>
+                    Open the Git panel
+                  </button>
+                  <button onclick={this.didClickGitHubButton} className='btn btn-primary'>
+                    Open the GitHub panel
+                  </button>
+                </p>
+                <p className='welcome-note'>
+                  <strong>Next time:</strong> You can toggle the Git tab by clicking on the
+                  <span className="icon icon-diff" /> button in your status bar.
                 </p>
               </div>
             </details>
@@ -267,6 +296,16 @@ export default class GuideView {
   didClickProjectButton () {
     this.props.reporterProxy.sendEvent('clicked-project-cta')
     atom.commands.dispatch(atom.views.getView(atom.workspace), 'application:open')
+  }
+
+  didClickGitButton() {
+    this.props.reporterProxy.sendEvent('clicked-git-cta')
+    atom.commands.dispatch(atom.views.getView(atom.workspace), 'github:toggle-git-tab')
+  }
+
+  didClickGitHubButton() {
+    this.props.reporterProxy.sendEvent('clicked-github-cta')
+    atom.commands.dispatch(atom.views.getView(atom.workspace), 'github:toggle-github-tab')
   }
 
   didClickPackagesButton () {

--- a/styles/welcome.less
+++ b/styles/welcome.less
@@ -77,7 +77,7 @@
     padding: 1em 1.5em;
     font-size: 1.1em;
     font-weight: 300;
-    line-height: 1.2;
+    line-height: 1.4;
     cursor: pointer;
     &:hover {
       color: lighten(@text-color, 4%);
@@ -106,6 +106,10 @@
     padding: 1.5em;
     .welcome-note {
       margin-bottom: 0;
+    }
+    .btn {
+      margin-top: @component-padding/3;
+      margin-bottom: @component-padding/3;
     }
   }
 

--- a/styles/welcome.less
+++ b/styles/welcome.less
@@ -176,6 +176,14 @@
   &-note {
     font-size: .86em;
     color: @text-color-subtle;
+
+    .icon {
+      margin-left: 5px;
+    }
+
+    .icon::before {
+      margin-right: 0;
+    }
   }
 
   &-footer {


### PR DESCRIPTION
Add a "version control with Git and GitHub" section to the Welcome panes to aid discoverability of the GitHub package functionality without eating a bunch of screen real estate on that crucial first launch. See atom/github#872.

<img width="586" alt="screen shot 2017-05-25 at 11 12 58 am" src="https://cloud.githubusercontent.com/assets/17565/26456461/21605938-413b-11e7-8a72-0f21559023bb.png">

/cc @simurai 