### PR TITLE
Fix "Show Welcome Guide when opening Atom" label

### DIFF
--- a/lib/welcome-view.js
+++ b/lib/welcome-view.js
@@ -69,8 +69,10 @@ export default class WelcomeView {
           </section>
 
           <section className='welcome-panel'>
-            <input className='input-checkbox' type='checkbox' id='show-welcome-on-startup' checked={atom.config.get('welcome.showOnStartup')} onchange={this.didChangeShowOnStartup} />
-            <label for='show-welcome-on-startup'>Show Welcome Guide when opening Atom</label>
+            <label>
+              <input className='input-checkbox' type='checkbox' checked={atom.config.get('welcome.showOnStartup')} onchange={this.didChangeShowOnStartup} />
+              Show Welcome Guide when opening Atom
+            </label>
           </section>
 
           <footer className='welcome-footer'>


### PR DESCRIPTION
### Description of the Change

This makes the "Show Welcome Guide when opening Atom" label clickable by moving the input inside.

**Bonus**: Wrapping is improved too.

Before | After
--- | ---
![checkbox-before](https://user-images.githubusercontent.com/378023/27722135-6ccd052a-5da0-11e7-88ee-e608b36ad298.gif) | ![checkbox](https://user-images.githubusercontent.com/378023/27722134-6cca1d1a-5da0-11e7-82dc-6c136bae0424.gif)


### Alternate Designs

We could keep using the `id` and `for` attributes, but for some reason the `for` gets stripped when rendered. But wrapping would still be bad.


### Benefits

- Label is clickable
- Better wrapping


### Possible Drawbacks

None


### Applicable Issues

Fixes #63
