### PR TITLE
Fix GitHub icon in 'Telemetry Consent' page

### DIFF
--- a/styles/welcome.less
+++ b/styles/welcome.less
@@ -163,17 +163,16 @@
     .icon::before {
       // Make these octicons look good inlined with text
       position: relative;
-      top: 1px;
+      top: 4px;
       width: auto;
       margin-right: 0;
       font-size: 1.5em;
     }
 
     .icon-logo-github::before {
-      // This Octicon has a lot of extra whitespace at the bottom, so it needs
-      // to be moved down more to compensate.
-      // See https://github.com/github/octicons/issues/59
-      top: 3px;
+      top: 2px;
+      font-size: 3.6em;
+      vertical-align: top;
     }
   }
 


### PR DESCRIPTION
This depends on [atom/atom#13138](https://github.com/atom/atom/pull/13138) and [atom/about/#43](https://github.com/atom/about/pull/43)

### Description of the Change
Resize GitHub icon and align text with icons.

**Before**

<img width="536" alt="screen shot 2017-09-03 at 4 11 25 pm" src="https://user-images.githubusercontent.com/7171098/30003644-ea30877c-90d5-11e7-9c47-066b40cde423.png">

**After**

<img width="538" alt="screen shot 2017-09-03 at 5 54 12 pm" src="https://user-images.githubusercontent.com/7171098/30003649-f721bdac-90d5-11e7-807d-78e89fa1a7e9.png">

