### PR TITLE
Update consent copy

### DIFF
--- a/lib/consent-view.js
+++ b/lib/consent-view.js
@@ -35,7 +35,7 @@ export default class ConsentView {
             </a>
           </div>
           <div className='welcome-consent'>
-            <p>Help improve Atom by sending your <strong>usage data</strong> to the Atom team. The resulting data plays a key role in deciding what we focus on next.</p>
+            <p>Help improve Atom by sending your <strong>usage data</strong> anonymously to the Atom team. The resulting data plays a key role in deciding what we focus on next.</p>
 
             <div className='welcome-consent-choices'>
               <div>

--- a/lib/consent-view.js
+++ b/lib/consent-view.js
@@ -35,7 +35,7 @@ export default class ConsentView {
             </a>
           </div>
           <div className='welcome-consent'>
-            <p>Help improve Atom by sending your <strong>usage data</strong> anonymously to the Atom team. The resulting data plays a key role in deciding what we focus on next.</p>
+            <p>Help improve Atom by sending your anonymous <strong>usage data</strong> to the Atom team. The resulting data plays a key role in deciding what we focus on next.</p>
 
             <div className='welcome-consent-choices'>
               <div>

--- a/lib/consent-view.js
+++ b/lib/consent-view.js
@@ -35,18 +35,17 @@ export default class ConsentView {
             </a>
           </div>
           <div className='welcome-consent'>
-            <p>To help improve Atom, you can anonymously send usage stats to the team. The resulting data plays a key role in deciding what to focus on.</p>
-            <p className='welcome-note'>The data we send is minimal. Broadly, we send things like startup time, session time, and exceptions — never code or paths. See the <a onclick={this.openMetricsPackage.bind(this)}>atom/metrics package</a> for details on what data is sent.</p>
+            <p>Help improve Atom by sending your <strong>usage data</strong> to the Atom team. The resulting data plays a key role in deciding what we focus on next.</p>
 
             <div className='welcome-consent-choices'>
               <div>
-                <button className='btn' onclick={this.decline.bind(this)}>No, I don't want to help</button>
-                <p className='welcome-note'>By opting out, your usage patterns will not be taken into account. We only register that you opted-out.</p>
+                <button className='btn btn-primary' onclick={this.consent.bind(this)}>Yes, send my usage data</button>
+                <p className='welcome-note'>Including exception and crash reports. See the <a onclick={this.openMetricsPackage.bind(this)}>atom/metrics package</a> for more details.</p>
               </div>
 
               <div>
-                <button className='btn btn-primary' onclick={this.consent.bind(this)}>Yes, I want to help improve Atom</button>
-                <p className='welcome-note'>You are helping us assess Atom's performance and understand usage patterns.</p>
+                <button className='btn btn-primary' onclick={this.decline.bind(this)}>No, do not send my usage data</button>
+                <p className='welcome-note'>Note: We only register anonymously that you opted-out.</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This updates the telemetry consent copy.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/378023/53000769-71b04300-346c-11e9-8a72-02f75ac345e6.png) | ![after](https://user-images.githubusercontent.com/378023/53138040-4e020f80-35c8-11e9-8ff7-2e22f3c78dcd.png)

### Alternate Designs

N/A

### Benefits

It removes the "dark patterns" of the current design.

- By making both buttons blue, both options get equal importance.
- The copy doesn't make users feel guilty for "not helping".
- The copy is reduced which might encourage people to read it.

### Possible Drawbacks

- This might affect how many people opt-in vs opt-out.
- We give the community another chance to discuss this topic.

### Applicable Issues

None, but it's something that we got called out for in the past.
