### PR TITLE
Fix field names used by the welcome package metric events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -4,7 +4,7 @@ This document specifies all the data (along with the format) which gets sent fro
 
 ## Counters
 
-Currently the Welcome package does not log any counter event.
+Currently the Welcome package does not log any counter events.
 
 ## Timing events
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -8,7 +8,7 @@ Currently the Welcome package does not log any counter event.
 
 ## Timing events
 
-Currently the Welcome package does not log any timing event.
+Currently the Welcome package does not log any timing events.
 
 ## Standard events
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,36 @@
+# Events specification
+
+This document specifies all the data (along with the format) which gets send from the Welcome package to the GitHub analytics pipeline. This document follows the same format and nomenclature than the [Atom Core Events spec](https://github.com/atom/metrics/blob/master/docs/events.md).
+
+## Counters
+
+Currently the Welcome package does not log any counter event.
+
+## Timing events
+
+Currently the Welcome package does not log any timing event.
+
+## Standard events
+
+#### Welcome package shown
+
+* **eventType**: `welcome-v1`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `ea` | `show-on-initial-load`
+
+
+#### Click on links
+
+* **eventType**: `welcome-v1`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `ea` | link that was clicked
+
+(There are many potential values for the `ea` param, e.g: `clicked-welcome-atom-docs-link`,`clicked-welcome-atom-org-link`, `clicked-project-cta`, `clicked-init-script-cta`, ...).
+
+

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,6 +1,6 @@
 # Events specification
 
-This document specifies all the data (along with the format) which gets send from the Welcome package to the GitHub analytics pipeline. This document follows the same format and nomenclature than the [Atom Core Events spec](https://github.com/atom/metrics/blob/master/docs/events.md).
+This document specifies all the data (along with the format) which gets sent from the Welcome package to the GitHub analytics pipeline. This document follows the same format and nomenclature as the [Atom Core Events spec](https://github.com/atom/metrics/blob/master/docs/events.md).
 
 ## Counters
 

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -4,20 +4,22 @@ export default class ReporterProxy {
   constructor () {
     this.reporter = null
     this.queue = []
+    this.eventType = 'welcome-v1'
   }
 
   setReporter (reporter) {
     this.reporter = reporter
     let customEvent
+
     while ((customEvent = this.queue.shift())) {
-      this.reporter.addCustomEvent(customEvent.category, customEvent)
+      this.reporter.addCustomEvent(this.eventType, customEvent)
     }
   }
 
   sendEvent (action, label, value) {
-    const event = { action, label, value, category: 'welcome-v1' }
+    const event = { ea: action, el: label, ev: value }
     if (this.reporter) {
-      this.reporter.addCustomEvent(event.category, event)
+      this.reporter.addCustomEvent(this.eventType, event)
     } else {
       this.queue.push(event)
     }

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -19,7 +19,7 @@ export default class ReporterProxy {
     if (this.reporter) {
       this.reporter.addCustomEvent(event.category, event)
     } else {
-      this.queue.push([event])
+      this.queue.push(event)
     }
   }
 }

--- a/test/welcome.test.js
+++ b/test/welcome.test.js
@@ -132,8 +132,8 @@ describe('Welcome', () => {
         welcomePackage.reporterProxy.setReporter(reporter1)
 
         assert.deepEqual(reporter1.reportedEvents, [
-          [{category: 'welcome-v1', action: 'foo', label: 'bar', value: 'baz'}],
-          [{category: 'welcome-v1', action: 'foo2', label: 'bar2', value: 'baz2'}]
+          {category: 'welcome-v1', action: 'foo', label: 'bar', value: 'baz'},
+          {category: 'welcome-v1', action: 'foo2', label: 'bar2', value: 'baz2'}
         ])
 
         welcomePackage.consumeReporter(reporter2)

--- a/test/welcome.test.js
+++ b/test/welcome.test.js
@@ -124,16 +124,26 @@ describe('Welcome', () => {
       it('sends all queued events', () => {
         welcomePackage.reporterProxy.queue.length = 0
 
-        const reporter1 = {addCustomEvent (category, event) { this.reportedEvents.push(event) }, reportedEvents: []}
-        const reporter2 = {addCustomEvent (category, event) { this.reportedEvents.push(event) }, reportedEvents: []}
+        const reporter1 = {
+          addCustomEvent (category, event) {
+            this.reportedEvents.push({ category, ...event })
+          },
+          reportedEvents: []
+        }
+        const reporter2 = {
+          addCustomEvent (category, event) {
+            this.reportedEvents.push({ category, ...event })
+          },
+          reportedEvents: []
+        }
 
-        welcomePackage.reporterProxy.sendEvent('foo', 'bar', 'baz')
-        welcomePackage.reporterProxy.sendEvent('foo2', 'bar2', 'baz2')
+        welcomePackage.reporterProxy.sendEvent('foo', 'bar', 10)
+        welcomePackage.reporterProxy.sendEvent('foo2', 'bar2', 60)
         welcomePackage.reporterProxy.setReporter(reporter1)
 
         assert.deepEqual(reporter1.reportedEvents, [
-          {category: 'welcome-v1', action: 'foo', label: 'bar', value: 'baz'},
-          {category: 'welcome-v1', action: 'foo2', label: 'bar2', value: 'baz2'}
+          {category: 'welcome-v1', ea: 'foo', el: 'bar', ev: 10},
+          {category: 'welcome-v1', ea: 'foo2', el: 'bar2', ev: 60}
         ])
 
         welcomePackage.consumeReporter(reporter2)


### PR DESCRIPTION
### Description of the Change

This PR includes three changes:

* A fix to send the events that were queued correctly (they were sent incorrectly in a nested array).
* A fix to use the correct field names for all the events.
* An added doc to specify the format of the events for this package.

The changes of the  metric events field names have been done to match the names that `atom/metric` uses ([source](https://github.com/atom/metrics/blob/master/lib/reporter.js#L53-L59)), so our analytics pipeline can process them correctly.

Ideally the name of the fields would be fixed by `atom/metrics` so other packages do not have to worry about using the correct fields, but this can be tackled in the future.

### Test plan

- [x] Check that the expected payload is sent to GitHub's backend. To do so, I've had to edit the code of the `atom/telemetry` package (more specifically, I've manually modified `node_modules/telemetry-github/out/index.js` to set the variable `this.isDevMode` to `false` ([code](https://github.com/atom/telemetry/blob/master/src/index.ts#L108)). I've also had to increase how often Atom sends metrics, since by default it only sends them every 24 hours. To do so, I've set the variables `DailyStatsReportIntervalInMs` and `ReportingLoopIntervalInMs` located in the previous file to something like `15000` ([code](https://github.com/atom/telemetry/blob/master/src/index.ts#L20-L23)).
- [x] Check that the data gets propagated correctly to our analytics pipeline.

### Alternate Designs

N/A

### Benefits

* Easier processing in our backends (we can reuse the processing for custom events).

### Possible Drawbacks

N/A

### Applicable Issues

N/A
