### PR TITLE
Update README to deprecate repository and redirect readers to atom/atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### This package is now a part of the [core Atom repository](https://github.com/atom/atom/tree/master/packages/welcome), please direct all issues and pull requests there in the future!
+
+---
+
 ## Welcome package
 [![macOS Build Status](https://travis-ci.org/atom/welcome.svg?branch=master)](https://travis-ci.org/atom/welcome)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/c3ssyte35ivvnt62/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/welcome/branch/master)


### PR DESCRIPTION
As of https://github.com/atom/atom/pull/19772, the welcome package is now a part of the core Atom repository. This pull request updates README.md to reflect that fact. We'll be archiving this repository shortly.

/cc https://github.com/atom/atom/issues/18285